### PR TITLE
changed staffer-image class so images clipped properly

### DIFF
--- a/_sass/custom/staffer.scss
+++ b/_sass/custom/staffer.scss
@@ -3,10 +3,10 @@
   margin: $sp-4 0;
 
   .staffer-image {
-    border-radius: 50%;
-    height: 100px;
+    clip-path: circle();
+    height: auto;
+    width: 100px;
     margin-right: $sp-4;
-    width: auto;
   }
 
   .anchor-heading {
@@ -31,7 +31,10 @@
   }
 
   .staffer-meta {
-    dt, dd, dd + dt {
+
+    dt,
+    dd,
+    dd+dt {
       margin-top: 0;
     }
   }


### PR DESCRIPTION
Rectangular images with border 50% turn into ovals. Using clip-path ensures images are circles.
Some screenshots show cutoff (e.g between Emily and Ken) but this is just because I took screenshots while scrolling and the spacing isn't accurately depicted in the below screenshots.
<img width="742" alt="image" src="https://github.com/user-attachments/assets/7500ef37-3523-408e-a4c4-0ab093b0b30a">
<img width="742" alt="image" src="https://github.com/user-attachments/assets/338ad76c-b3da-46a4-af1b-9adaf4f7b186">
<img width="742" alt="image" src="https://github.com/user-attachments/assets/8a0071c2-e71b-43af-af9d-8ee218d0e820">